### PR TITLE
Fix translation key in UserFormFields

### DIFF
--- a/src/features/users/components/UserFormFields.tsx
+++ b/src/features/users/components/UserFormFields.tsx
@@ -29,7 +29,7 @@ export default function UserFormFields({
             })}
           />
           {errors.first_name && (
-            <span className="text-red-400 p-1">{t('fieldRquired')}</span>
+            <span className="text-red-400 p-1">{t('fieldRequired')}</span>
           )}
         </div>
       </div>
@@ -47,7 +47,7 @@ export default function UserFormFields({
             })}
           />
           {errors.last_name && (
-            <span className="text-red-400 p-1">{t('fieldRquired')}</span>
+            <span className="text-red-400 p-1">{t('fieldRequired')}</span>
           )}
         </div>
       </div>
@@ -65,7 +65,7 @@ export default function UserFormFields({
             })}
           />
           {errors.email && (
-            <span className="text-red-400 p-1">{t('fieldRquired')}</span>
+            <span className="text-red-400 p-1">{t('fieldRequired')}</span>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- fix typo in user form error message key

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: TS errors / missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68434c15aec883238ad503e04c5f8735