### PR TITLE
Fix i18n keys

### DIFF
--- a/src/features/posts/components/PostCard.tsx
+++ b/src/features/posts/components/PostCard.tsx
@@ -36,7 +36,7 @@ export const PostCard = ({
             <ThumbsUp />
           </Button>
           <div className="text-sm text-gray-400">
-            {likes || 0} {t('likes')}
+            {likes || 0} {t('posts.likes')}
           </div>
           {canDelete && (
             <Button

--- a/src/features/posts/components/PostsList.tsx
+++ b/src/features/posts/components/PostsList.tsx
@@ -28,7 +28,7 @@ const PostsList = () => {
         onSuccess: () => {
           toast({
             className: 'bg-woodsmoke-950 text-green-400 p-4',
-            title: `${t('post')} created`,
+            title: `${t('posts.post')} created`,
           });
         },
         onError: () => {
@@ -48,7 +48,7 @@ const PostsList = () => {
         onSuccess: () => {
           toast({
             className: 'bg-woodsmoke-950 text-green-400 p-4',
-            title: `${t('post')} deleted`,
+            title: `${t('posts.post')} deleted`,
           });
         },
         onError: () => {

--- a/src/features/users/components/UserFormFields.tsx
+++ b/src/features/users/components/UserFormFields.tsx
@@ -18,7 +18,7 @@ export default function UserFormFields({
       <div className="flex flex-col items-center">
         <div className="my-4 flex flex-col">
           <label htmlFor="first_name" className="font-semibold my-1">
-            {t('first_name')}:
+            {t('users.first_name')}:
           </label>
           <input
             className="p-3 px-4 rounded-lg w-[300px]"
@@ -29,14 +29,14 @@ export default function UserFormFields({
             })}
           />
           {errors.first_name && (
-            <span className="text-red-400 p-1">{t('fieldRequired')}</span>
+            <span className="text-red-400 p-1">{t('users.fieldRequired')}</span>
           )}
         </div>
       </div>
       <div className="flex flex-col items-center">
         <div className="my-4 flex flex-col">
           <label htmlFor="last_name" className="font-semibold my-1">
-            {t('last_name')}:
+            {t('users.last_name')}:
           </label>
           <input
             className="p-3 px-4 rounded-lg w-[300px]"
@@ -47,14 +47,14 @@ export default function UserFormFields({
             })}
           />
           {errors.last_name && (
-            <span className="text-red-400 p-1">{t('fieldRequired')}</span>
+            <span className="text-red-400 p-1">{t('users.fieldRequired')}</span>
           )}
         </div>
       </div>
       <div className="flex flex-col items-center">
         <div className="my-4 flex flex-col">
           <label htmlFor="email" className="font-semibold my-1">
-            {t('email')}:
+            {t('users.email')}:
           </label>
           <input
             className="p-3 px-4 rounded-lg w-[300px]"
@@ -65,7 +65,7 @@ export default function UserFormFields({
             })}
           />
           {errors.email && (
-            <span className="text-red-400 p-1">{t('fieldRequired')}</span>
+            <span className="text-red-400 p-1">{t('users.fieldRequired')}</span>
           )}
         </div>
       </div>

--- a/src/features/users/components/UserList.tsx
+++ b/src/features/users/components/UserList.tsx
@@ -61,7 +61,7 @@ const UserList = memo(() => {
     (userId: number) => {
       setDeletingUserId(userId);
       deleteMutation.mutate(userId, {
-        onSuccess: () => showSuccessToast(`${t('user')} deleted`),
+        onSuccess: () => showSuccessToast(`${t('users.user')} deleted`),
         onError: () => showErrorToast('Error on delete user'),
         onSettled: () => setDeletingUserId(null),
       });
@@ -101,7 +101,7 @@ const UserList = memo(() => {
             role="status"
             aria-live="polite"
           >
-            {t('loading')}...
+            {t('common.loading')}...
           </div>
         ) : (data?.users ?? []).length > 0 ? (
           (data?.users ?? []).map((item: User) => (
@@ -118,7 +118,7 @@ const UserList = memo(() => {
             role="status"
             aria-live="polite"
           >
-            {t('noUsersFound')}
+            {t('users.noUsersFound')}
           </p>
         )}
       </div>

--- a/src/features/users/pages/EditUserPage.tsx
+++ b/src/features/users/pages/EditUserPage.tsx
@@ -28,7 +28,7 @@ function EditUserPage() {
     updateMutation.mutate(user);
     toast({
       className: 'bg-woodsmoke-950 text-green-500 p-4',
-      title: `${t('user')} ${t('updated')}`,
+      title: `${t('users.user')} ${t('users.updated')}`,
     });
   };
 
@@ -52,7 +52,7 @@ function EditUserPage() {
   return (
     <div className="flex justify-center h-screen w-full p-[20px]">
       <div className="p-4 rounded-lg">
-        <h2 className="text-center font-bold text-lg">{t('userInfo')}</h2>
+        <h2 className="text-center font-bold text-lg">{t('users.userInfo')}</h2>
         {user && (
           <form
             onSubmit={handleSubmit(onSubmit)}
@@ -68,7 +68,7 @@ function EditUserPage() {
                 {updateMutation.isPending ? (
                   <CgSpinner className="animate-spin h-4 w-4" />
                 ) : (
-                  t('save')
+                  t('users.save')
                 )}
               </button>
 
@@ -76,7 +76,7 @@ function EditUserPage() {
                 onClick={() => navigate('/users')}
                 className="button text-sm text-red-400 mx-2"
               >
-                {t('back')}
+                {t('common.back')}
               </button>
             </div>
           </form>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -18,11 +18,14 @@
     "save": "Save",
     "cancel": "Cancel",
     "fieldRequired": "This field is required",
-    "updated": "Updated"
+    "updated": "Updated",
+    "noUsersFound": "No users found"
   },
   "posts": {
     "posts": "Posts",
-    "newsList": "News List"
+    "newsList": "News List",
+    "post": "Post",
+    "likes": "Likes"
   },
   "common": {
     "loading": "Loading",
@@ -31,15 +34,15 @@
     "back": "Back",
     "home": "Home"
   },
-  "sideMenu":{
+  "sideMenu": {
     "users": "Users",
     "posts": "Posts",
     "openRouter": "Open Router AI",
-    "challenges":{
+    "challenges": {
       "challenges": "Challenges",
       "tictactoe": "Tic Tac Toe",
       "localStorage": "Local Storage",
-      "accordion": "Accordion",	
+      "accordion": "Accordion",
       "habitChart": "Habit Chart"
     }
   }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -18,11 +18,14 @@
     "save": "Guardar",
     "cancel": "Cancelar",
     "fieldRequired": "Este campo es obligatorio",
-    "updated": "Actualizado"
+    "updated": "Actualizado",
+    "noUsersFound": "No se encontraron usuarios"
   },
   "posts": {
     "posts": "Noticias",
-    "newsList": "Lista de Noticias"
+    "newsList": "Lista de Noticias",
+    "post": "Noticia",
+    "likes": "Me gusta"
   },
   "common": {
     "loading": "Cargando",
@@ -31,14 +34,14 @@
     "back": "Volver",
     "home": "Inicio"
   },
-  "sideMenu":{
+  "sideMenu": {
     "users": "Usuarios",
     "posts": "Noticias",
-    "challenges":{
+    "challenges": {
       "challenges": "Desafíos",
       "tictactoe": "Tic Tac Toe",
       "localStorage": "Almacenamiento Local",
-      "accordion": "Acordeón",	
+      "accordion": "Acordeón",
       "habitChart": "Gráfico de Hábitos"
     }
   }


### PR DESCRIPTION
## Summary
- update translations with `post`, `likes` and `noUsersFound`
- fix UserList to use new i18n keys
- update EditUserPage keys
- scope user form fields translations
- reference posts namespace for likes and post messages

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6843508d92bc83238e2f2322b8cd946d