### PR TITLE
Fix translation key path

### DIFF
--- a/src/components/side-menu/useSideMenuTranslations.ts
+++ b/src/components/side-menu/useSideMenuTranslations.ts
@@ -7,7 +7,7 @@ export const useSideMenuTranslations = () => {
     users: t('sideMenu.users'),
     posts: t('sideMenu.posts'),
     openRouter: t('sideMenu.openRouter'),
-    challenges: t('sideMenu.challenges.challenges'),
+    challenges: t(TRANSLATION_KEYS.SIDE_MENU.CHALLENGES.CHALLENGES),
     tictactoe: t(TRANSLATION_KEYS.SIDE_MENU.CHALLENGES.TICTACTOE),
     localStorage: t(TRANSLATION_KEYS.SIDE_MENU.CHALLENGES.LOCAL_STORAGE),
     accordion: t(TRANSLATION_KEYS.SIDE_MENU.CHALLENGES.ACCORDION),

--- a/src/constants/translationKeys.ts
+++ b/src/constants/translationKeys.ts
@@ -6,7 +6,7 @@ export const TRANSLATION_KEYS = {
       OPEN_ROUTER: 'sideMenu.openRouter',
     },
     CHALLENGES: {
-      CHALLENGES: 'sideMenu.titles.challenges',
+      CHALLENGES: 'sideMenu.challenges.challenges',
       TICTACTOE: 'sideMenu.challenges.tictactoe',
       LOCAL_STORAGE: 'sideMenu.challenges.localStorage',
       ACCORDION: 'sideMenu.challenges.accordion',


### PR DESCRIPTION
## Summary
- fix `sideMenu.challenges.challenges` path in constants
- use new constant in side menu translations

## Testing
- `npm run lint` *(fails: couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_684352016e6c832391001f8d1da86f6d