### PR TITLE
Remove unused i18next backend

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,7 +1,6 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
-import Backend from 'i18next-http-backend';
 
 // Translation files
 import translationEN from './locales/en/translation.json';
@@ -17,7 +16,6 @@ const resources = {
 };
 
 i18n
-  .use(Backend)
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({


### PR DESCRIPTION
## Summary
- remove `i18next-http-backend` from the i18n setup

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684353e46f6083239d991d63929e9965