### PR TITLE
Add user edit modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { ThemeProvider } from '@/components/theme-provider';
 import { Outlet } from 'react-router';
 import { Toaster } from '@/components/ui/toaster';
-import { Navbar, SideMenu } from '@/components';
+import { Navbar, SideMenu, Modal } from '@/components';
 
 function App() {
   return (
@@ -13,6 +13,7 @@ function App() {
           <Outlet />
         </div>
         <Toaster />
+        <Modal />
       </div>
     </ThemeProvider>
   );

--- a/src/features/users/components/EditUserModal.tsx
+++ b/src/features/users/components/EditUserModal.tsx
@@ -1,0 +1,70 @@
+import { useForm } from 'react-hook-form';
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CgSpinner } from 'react-icons/cg';
+import { useUser } from '../hooks/useUser';
+import { User } from '../types/User';
+import { useToast } from '@/components/ui/use-toast';
+import UserFormFields from './UserFormFields';
+import { useModalStore } from '@/components/modal/useModalStore';
+
+interface EditUserModalProps {
+  user: User;
+}
+
+function EditUserModal({ user }: EditUserModalProps) {
+  const { t } = useTranslation();
+  const { toast } = useToast();
+  const { updateMutation } = useUser();
+  const closeModal = useModalStore((state) => state.closeModal);
+
+  const {
+    register,
+    setValue,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<User>();
+
+  useEffect(() => {
+    if (user) {
+      setValue('id', user.id);
+      setValue('first_name', user.first_name);
+      setValue('last_name', user.last_name);
+      setValue('email', user.email);
+      setValue('avatar', user.avatar);
+    }
+  }, [user, setValue]);
+
+  const onSubmit = (data: User) => {
+    updateMutation.mutate(data, {
+      onSuccess: () => {
+        toast({
+          className: 'bg-woodsmoke-950 text-green-500 p-4',
+          title: `${t('users.user')} ${t('users.updated')}`,
+        });
+        closeModal();
+      },
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="rounded-xl p-7 w-full">
+      <UserFormFields register={register} errors={errors} t={t} />
+      <div className="flex justify-center p-6">
+        <button
+          className="button text-sm text-green-400 mx-2"
+          type="submit"
+          disabled={updateMutation.isPending}
+        >
+          {updateMutation.isPending ? (
+            <CgSpinner className="animate-spin h-4 w-4" />
+          ) : (
+            t('users.save')
+          )}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+export default EditUserModal;

--- a/src/features/users/components/UserRow.tsx
+++ b/src/features/users/components/UserRow.tsx
@@ -1,9 +1,11 @@
 import { memo, useCallback } from 'react';
 import { User } from '../types/User';
-import { Link } from 'react-router';
 import { FaEdit, FaTrash } from 'react-icons/fa';
 import { CgSpinner } from 'react-icons/cg';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { useModal } from '@/components/modal/useModal';
+import EditUserModal from './EditUserModal';
+import { useTranslation } from 'react-i18next';
 
 type UserRowProps = {
   user: User;
@@ -12,9 +14,16 @@ type UserRowProps = {
 };
 
 const UserRow = memo(({ user, isLoading, onDelete }: UserRowProps) => {
+  const { openModal } = useModal();
+  const { t } = useTranslation();
+
   const handleDelete = useCallback(() => {
     onDelete(user.id as number);
   }, [onDelete, user.id]);
+
+  const handleEdit = useCallback(() => {
+    openModal(t('users.userInfo'), <EditUserModal user={user} />);
+  }, [openModal, user, t]);
 
   return (
     <div className="flex hover:bg-dark hover:rounded-lg gap-2 flex-col text-center md:flex-row justify-between items-center md:text-left text-woodsmoke-300 h-fit md:h-[50px]">
@@ -52,9 +61,9 @@ const UserRow = memo(({ user, isLoading, onDelete }: UserRowProps) => {
         </div>
       </div>
       <div className="flex gap-2 w-fit">
-        <Link className="button w-full" to={`edit/${user.id}`}>
+        <button className="button w-full" onClick={handleEdit}>
           <FaEdit className="h-5 w-5" />
-        </Link>
+        </button>
         <button
           onClick={handleDelete}
           className="text-red-400 button w-full"


### PR DESCRIPTION
## Summary
- show global modal component
- add `EditUserModal` for editing user data
- switch edit button to open the modal instead of link

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68438009cb908323a1e85e2c64e14c1b