### PR TITLE
Implement dark/light theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,17 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ORM</title>
+    <script>
+      (function () {
+        const storageKey = 'vite-ui-theme';
+        const stored = localStorage.getItem(storageKey);
+        const systemPreference = window.matchMedia('(prefers-color-scheme: dark)').matches
+          ? 'dark'
+          : 'light';
+        const theme = stored === 'light' || stored === 'dark' ? stored : systemPreference;
+        document.documentElement.classList.add(theme);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orm",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orm",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "dependencies": {
         "@faker-js/faker": "^9.2.0",
         "@fortawesome/free-solid-svg-icons": "^6.6.0",

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -13,7 +13,7 @@ const Modal = () => {
       onClick={closeModal}
     >
       <div
-        className="bg-woodsmoke-950 rounded-lg shadow-lg p-6 w-full max-w-lg"
+        className="rounded-lg shadow-lg p-6 w-full max-w-lg bg-white text-gray-900 dark:bg-woodsmoke-950 dark:text-white"
         onClick={(e) => e.stopPropagation()}
       >
         <h2 className="text-2xl font-bold text-center mb-10">{title}</h2>

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -14,7 +14,7 @@ const NavBar = memo(() => {
   const { isOpen, toggleMenu } = useMenuTrigger();
 
   return (
-    <header className="p-4 bg-gray-900 border-b border-gray-700 text-white">
+    <header className="p-4 border-b bg-gray-100 text-gray-900 border-gray-200 dark:bg-gray-900 dark:text-white dark:border-gray-700">
       <div className="flex justify-between gap-2 items-center pr-4">
         <div>
           <button

--- a/src/components/side-menu/index.tsx
+++ b/src/components/side-menu/index.tsx
@@ -28,7 +28,7 @@ const SideMenu = memo(() => {
             ? 'hidden sm:flex'
             : 'w-full fixed z-50 inset-0 sm:w-[300px] sm:min-w-[200px]'
         }
-        transition-all duration-200 border-r border-gray-700 p-4 sm:relative flex flex-col items-center bg-gray-900 text-center text-white
+        transition-all duration-200 border-r p-4 sm:relative flex flex-col items-center text-center bg-gray-100 text-gray-900 border-gray-200 dark:bg-gray-900 dark:text-white dark:border-gray-700
       `}
     >
       <div className={`w-full pt-1 ${isOpen ? 'text-center' : 'text-right'}`}>
@@ -100,7 +100,7 @@ const NavItem = memo(
         }`}
       >
         <div
-          className="flex items-center justify-between cursor-pointer py-2 p-3 rounded hover:bg-gray-800"
+          className="flex items-center justify-between cursor-pointer py-2 p-3 rounded hover:bg-gray-200 dark:hover:bg-gray-800"
           onClick={() =>
             item.subItems ? toggleAccordion(index) : navigate(item.route)
           }
@@ -145,7 +145,7 @@ const NavItem = memo(
               {item.subItems.map((subItem: SubMenuItem, index: number) => (
                 <div
                   key={index}
-                  className="cursor-pointer pl-12 py-2 p-3 rounded hover:bg-gray-800"
+                  className="cursor-pointer pl-12 py-2 p-3 rounded hover:bg-gray-200 dark:hover:bg-gray-800"
                   onClick={() => navigate(subItem.route)}
                   tabIndex={0}
                   role="button"

--- a/src/features/auth/components/AuthAvatarMenu.tsx
+++ b/src/features/auth/components/AuthAvatarMenu.tsx
@@ -10,7 +10,7 @@ import {
 import { useNavigate } from 'react-router';
 
 export default function AuthAvatarMenu() {
-  let navigate = useNavigate();
+  const navigate = useNavigate();
 
   return (
     <DropdownMenu>

--- a/src/features/challenges/components/HabitChart.tsx
+++ b/src/features/challenges/components/HabitChart.tsx
@@ -33,7 +33,7 @@ const HabitChart = () => {
                 <tr key={i}>
                   {Array(7)
                     .fill(null)
-                    .map((_col, j): any => {
+                    .map((_col, j) => {
                       // Highlight the cell if the habitData value matches the row condition
                       return visibleData[j] > 0 &&
                         visibleData[j] >= reverseIndex + 1 ? (

--- a/src/features/challenges/components/LocaStorage.tsx
+++ b/src/features/challenges/components/LocaStorage.tsx
@@ -18,7 +18,7 @@ const useLocalStorage = (key: string, initialValue: string) => {
 function LocalStorage() {
   const { value, setValue } = useLocalStorage('inputValue', '');
 
-  const handleChange = (e: any) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
   };
 

--- a/src/features/challenges/components/Tictactoe.tsx
+++ b/src/features/challenges/components/Tictactoe.tsx
@@ -28,7 +28,7 @@ const TicTacToe = () => {
     }
   };
 
-  const checkWinner = (board: any) => {
+  const checkWinner = (board: (string | null)[]) => {
     const winConditions = [
       [0, 1, 2],
       [3, 4, 5],

--- a/src/features/posts/components/PostCard.tsx
+++ b/src/features/posts/components/PostCard.tsx
@@ -24,9 +24,9 @@ export const PostCard = ({
   const { t } = useTranslation();
 
   return (
-    <div className="bg-dark rounded-lg shadow-md overflow-hidden border-4 border-primary">
+    <div className="rounded-lg shadow-md overflow-hidden border-4 border-primary bg-white text-gray-900 dark:bg-dark dark:text-white">
       <div className="relative">
-        <div className="pr-2 flex justify-start items-center absolute z-10 bottom-2 right-3 bg-dark rounded-lg">
+        <div className="pr-2 flex justify-start items-center absolute z-10 bottom-2 right-3 rounded-lg bg-gray-200 dark:bg-dark">
           <Button
             variant="ghost"
             size="icon"
@@ -56,9 +56,9 @@ export const PostCard = ({
           alt={`${post.user_email}'s post`}
           className="w-full h-48 object-cover rounded-sm"
         />
-        <div className="absolute inset-0 bg-gradient-to-t from-dark/90 to-transparent rounded-lg" />
+        <div className="absolute inset-0 bg-gradient-to-t from-white/90 to-transparent dark:from-dark/90 rounded-lg" />
       </div>
-      <div className="p-6 text-white">
+      <div className="p-6 text-gray-900 dark:text-white">
         <h3 className="text-xl font-semibold mb-2">{post.title}</h3>
         <p className="text-sm mb-4">{post.content}</p>
         <div className="flex items-center justify-between">

--- a/src/features/posts/components/PostsList.tsx
+++ b/src/features/posts/components/PostsList.tsx
@@ -27,13 +27,13 @@ const PostsList = () => {
       {
         onSuccess: () => {
           toast({
-            className: 'bg-woodsmoke-950 text-green-400 p-4',
+            className: 'p-4 bg-white text-green-600 dark:bg-woodsmoke-950 dark:text-green-400',
             title: `${t('posts.post')} created`,
           });
         },
         onError: () => {
           toast({
-            className: 'bg-woodsmoke-950 text-red-400 p-4',
+            className: 'p-4 bg-white text-red-600 dark:bg-woodsmoke-950 dark:text-red-400',
             title: `Error on create post`,
           });
         },
@@ -47,13 +47,13 @@ const PostsList = () => {
       deletePostMutation.mutate(postId, {
         onSuccess: () => {
           toast({
-            className: 'bg-woodsmoke-950 text-green-400 p-4',
+            className: 'p-4 bg-white text-green-600 dark:bg-woodsmoke-950 dark:text-green-400',
             title: `${t('posts.post')} deleted`,
           });
         },
         onError: () => {
           toast({
-            className: 'bg-woodsmoke-950 text-red-400 p-4',
+            className: 'p-4 bg-white text-red-600 dark:bg-woodsmoke-950 dark:text-red-400',
             title: `Error on delete post`,
           });
         },

--- a/src/features/users/components/EditUserModal.tsx
+++ b/src/features/users/components/EditUserModal.tsx
@@ -39,7 +39,7 @@ function EditUserModal({ user }: EditUserModalProps) {
     updateMutation.mutate(data, {
       onSuccess: () => {
         toast({
-          className: 'bg-woodsmoke-950 text-green-500 p-4',
+          className: 'p-4 bg-white text-green-600 dark:bg-woodsmoke-950 dark:text-green-500',
           title: `${t('users.user')} ${t('users.updated')}`,
         });
         closeModal();

--- a/src/features/users/components/UserList.tsx
+++ b/src/features/users/components/UserList.tsx
@@ -23,7 +23,7 @@ const UserList = memo(() => {
   const showSuccessToast = useCallback(
     (message: string) => {
       toast({
-        className: 'bg-woodsmoke-950 text-green-400 p-4',
+        className: 'p-4 bg-white text-green-600 dark:bg-woodsmoke-950 dark:text-green-400',
         title: message,
       });
     },
@@ -33,7 +33,7 @@ const UserList = memo(() => {
   const showErrorToast = useCallback(
     (message: string) => {
       toast({
-        className: 'bg-woodsmoke-950 text-red-400 p-4',
+        className: 'p-4 bg-white text-red-600 dark:bg-woodsmoke-950 dark:text-red-400',
         title: message,
       });
     },

--- a/src/features/users/components/UserRow.tsx
+++ b/src/features/users/components/UserRow.tsx
@@ -26,7 +26,7 @@ const UserRow = memo(({ user, isLoading, onDelete }: UserRowProps) => {
   }, [openModal, user, t]);
 
   return (
-    <div className="flex hover:bg-dark hover:rounded-lg gap-2 flex-col text-center md:flex-row justify-between items-center md:text-left text-woodsmoke-300 h-fit md:h-[50px]">
+    <div className="flex gap-2 flex-col text-center md:flex-row justify-between items-center md:text-left text-gray-800 dark:text-woodsmoke-300 h-fit md:h-[50px] hover:bg-gray-200 dark:hover:bg-dark hover:rounded-lg">
       <div className="hidden md:block md:w-[20px]">{user.id}</div>
       <div className="md:w-[50px]">
         <Avatar>

--- a/src/features/users/pages/EditUserPage.tsx
+++ b/src/features/users/pages/EditUserPage.tsx
@@ -27,7 +27,7 @@ function EditUserPage() {
   const onSubmit = (user: User) => {
     updateMutation.mutate(user);
     toast({
-      className: 'bg-woodsmoke-950 text-green-500 p-4',
+      className: 'p-4 bg-white text-green-600 dark:bg-woodsmoke-950 dark:text-green-500',
       title: `${t('users.user')} ${t('users.updated')}`,
     });
   };

--- a/src/stories/Button.tsx
+++ b/src/stories/Button.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import './button.css';
 
 export interface ButtonProps {
@@ -23,11 +21,15 @@ export const Button = ({
   label,
   ...props
 }: ButtonProps) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary
+    ? 'storybook-button--primary'
+    : 'storybook-button--secondary';
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={['storybook-button', `storybook-button--${size}`, mode].join(
+        ' '
+      )}
       style={{ backgroundColor }}
       {...props}
     >

--- a/src/stories/Header.tsx
+++ b/src/stories/Header.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Button } from './Button';
 import './header.css';
 
@@ -14,11 +12,21 @@ export interface HeaderProps {
   onCreateAccount?: () => void;
 }
 
-export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps) => (
+export const Header = ({
+  user,
+  onLogin,
+  onLogout,
+  onCreateAccount,
+}: HeaderProps) => (
   <header>
     <div className="storybook-header">
       <div>
-        <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+        <svg
+          width="32"
+          height="32"
+          viewBox="0 0 32 32"
+          xmlns="http://www.w3.org/2000/svg"
+        >
           <g fill="none" fillRule="evenodd">
             <path
               d="M10 0h12a10 10 0 0110 10v12a10 10 0 01-10 10H10A10 10 0 010 22V10A10 10 0 0110 0z"
@@ -47,7 +55,12 @@ export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps
         ) : (
           <>
             <Button size="small" onClick={onLogin} label="Log in" />
-            <Button primary size="small" onClick={onCreateAccount} label="Sign up" />
+            <Button
+              primary
+              size="small"
+              onClick={onCreateAccount}
+              label="Sign up"
+            />
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- add early theme script to index.html
- adjust Navbar, side menu and modal to support both themes
- tweak PostCard, UserRow and toast colors for light theme
- update PostsList and EditUser components with themed toasts

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68449d21468c832389109894c3c7eae7